### PR TITLE
Swap order of pages

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -12,22 +12,26 @@ const axios = require('axios');
 // Add your routes here - above the module.exports line
 
 router.post('/email-address', (req, res) => {
+  req.session.data['email-address'] = req.body.emailAddress
+  res.redirect('/consent');
+});
+
+router.post('/consent', (req, res) => {
     notifyClient
         .sendEmail(
           templateId='77168d68-46a1-44fb-90ea-c52173122c5d',
-          emailAddress=req.body.emailAddress,
+          emailAddress=req.session.data['email-address'],
           {reference: 'covid pass email'}
         )
-        .then(response => console.log(response))
+        .then(response => console.log('HTTP', response.status, response.config.url))
         .catch(err => console.error(err))
 
     axios
       .post('https://documents.cloudapps.digital/allow-email', {
-        'email-address': req.body.emailAddress
+        'email-address': req.session.data['email-address']
       })
-      .then(res => {
-        console.log(`statusCode: ${res.status}`);
-        console.log(res);
+      .then(response => {
+        console.log('HTTP', response.status, response.config.url);
       })
       .catch(error => {
         console.error(error);

--- a/app/views/consent.html
+++ b/app/views/consent.html
@@ -49,11 +49,11 @@
       GP surgery’s name and address
     </li>
       </ul>
-
+    <form method="post">
       {{ button({
-        "text": "I agree",
-        "href": "email-address"
+        "text": "I agree"
       }) }}
+    </form>
 
       {% from 'details/macro.njk' import details %}
 

--- a/app/views/email-address.html
+++ b/app/views/email-address.html
@@ -23,24 +23,21 @@
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-      <h1>
-
-      </h1>
 
       <form class="form" method="post">
         {{ input({
           "label": {
-              "text": "Enter your email address",
+              "text": "Enter your email addres",
               "isPageHeading": true,
               "classes": "nhsuk-label--l"
           },
           "id": "email_address",
           "name": "emailAddress",
-          "hint": {"text": "We’ll use this to send you a link to download a PDF of your COVID Pass."}
+          "hint": {"text": "We will check if you have an NHS login. If not, you can set one up."}
         }) }}
 
         {{ button({
-        "text": "Send email"
+        "text": "Continue"
         }) }}
       </form>
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -44,7 +44,7 @@
 
     {{ actionLink({
       "text": "Start",
-      "href": "/consent"
+      "href": "/email-address"
     }) }}
 
     </div>


### PR DESCRIPTION
# Before
1. give consent to share info
2. enter your email

# After
1. ‘log in’ using (just) your email address
2. give consent to share info

***

This should make it clearer that the consent page is asking for information that the NHS already holds, not telling the user what information the service is going to ask from them.